### PR TITLE
fix link to k/k in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ matches the version of kubernetes deployed.
 - `k8s-git`, _optional_  
   Must provide a git source tree of kubernetes. When configured, the [node image]
   will be built off of the checked-out revision of kubernetes.
-  This is typically a git resource, pointing to (a fork of) [k/k](github.com/kubernetes/kubernetes).
+  This is typically a git resource, pointing to (a fork of) [k/k](https://github.com/kubernetes/kubernetes).
 - `node-image`, _optional_
   Must provide an OCI image `image.tar` that will be used as a [node image]. This
   can be an image generated via


### PR DESCRIPTION
For some reason the readme is rendering the link as https://github.com/pivotal-k8s/kind-on-c/blob/master/github.com/kubernetes/kubernetes which confused me as I clicked through